### PR TITLE
fix : 버그 등 기능 구현 거의 다

### DIFF
--- a/src/admin/RoomManagement.java
+++ b/src/admin/RoomManagement.java
@@ -4,16 +4,16 @@ import javax.swing.*;
 import javax.swing.border.LineBorder;
 import java.awt.*;
 import java.util.List;
-import java.lang.StringBuilder;
 import app.BaseFrame;
 import common.model.Room;
 
 public class RoomManagement extends AdminView {
 	private JTextArea roomListArea;
+	private RoomManager roomManager;
 
 	public RoomManagement(BaseFrame baseframe) {
 		super(baseframe);
-		RoomManager roomManager=new RoomManager();
+		roomManager = new RoomManager();
 
 
 		JLabel infoLabel = new JLabel("회의실 목록");
@@ -34,7 +34,7 @@ public class RoomManagement extends AdminView {
 		addRoomBtn.setBounds(518, 50, 126, 23);
 		addRoomBtn.addActionListener(e -> baseframe.change(baseframe.panel, baseframe.adv));
 		adminPanel.add(addRoomBtn);
-		
+
 		JButton deleteRoomBtn = new JButton("회의실 삭제");
 		deleteRoomBtn.setBounds(518, 77, 126, 23);
 		deleteRoomBtn.addActionListener(e -> {
@@ -46,7 +46,7 @@ public class RoomManagement extends AdminView {
 			else JOptionPane.showMessageDialog(null, "회의실 삭제에 실패했습니다", "Message", JOptionPane.ERROR_MESSAGE);
 		});
 		adminPanel.add(deleteRoomBtn);
-		
+
 		JButton updateRoomBtn = new JButton("회의실 수정");
 		updateRoomBtn.setBounds(518, 104, 126, 23);
 		updateRoomBtn.addActionListener(e -> {
@@ -74,7 +74,7 @@ public class RoomManagement extends AdminView {
 	}
 
 	private void loadRoomList() {
-		List<Room> rooms = new RoomManager().getAllRooms();
+		List<Room> rooms = roomManager.getAllRooms();
 		StringBuilder sb = new StringBuilder();
 		for (Room r : rooms) {
 			sb.append("ID: ").append(r.getId())
@@ -85,15 +85,4 @@ public class RoomManagement extends AdminView {
 		roomListArea.setText(sb.toString());
 	}
 
-	private void loadRoomList() {
-		List<Room> rooms = new RoomManager().getAllRooms();
-		StringBuilder sb = new StringBuilder();
-		for (Room r : rooms) {
-			sb.append("ID: ").append(r.getId())
-					.append(" | 이름: ").append(r.getName())
-					.append(" | 인원: ").append(r.getCapacity())
-					.append("\n");
-		}
-		roomListArea.setText(sb.toString());
-	}
 }

--- a/src/app/BaseFrame.java
+++ b/src/app/BaseFrame.java
@@ -24,23 +24,25 @@ public class BaseFrame extends JFrame {
 
 	private User currentUser;
 
-	
+
 	public LoginController loginController;
 	public LoginResult loginResult;
 	public RegisterResult registerResult;
 
 	public BaseFrame() {
 		loginController=new LoginController();
-		
+
 		lgv = new LoginView(this);
 		suv = new SignUp(this);
-		//uif = new UserInfo(this);
 		dbv = new DashBoard(this);
 		adv = new RoomAdd(this);
 		rmv = new RoomManagement(this);
-		//lv = new LeaderView(this);
-		//mv = new MemberView(this);
 
+		// 로그인 후에 초기화될 View들은 처음에는 null로 두고
+		// 버튼은 비활성화 상태로 생성
+		uif = null;
+		lv = null;
+		mv = null;
 
 		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		setSize(1440, 1008);
@@ -61,16 +63,20 @@ public class BaseFrame extends JFrame {
 		panel.setLayout(null);
 		getContentPane().add(panel);
 
+		// 항상 사용 가능한 버튼들
 		addHeaderButton("로그인", 12, lgv);
 		addHeaderButton("회원가입", 119, suv);
-		addHeaderButton("사용자정보", 226, uif);
 		addHeaderButton("대시보드", 333, dbv);
-		addHeaderButton("회의실추가", 440, adv);
-		addHeaderButton("회의실관리", 547, rmv);
-		addHeaderButton("회의실검색", 654, lv);
-		addHeaderButton("회의실예약", 761, lv);
-		addHeaderButton("내회의관리", 868, lv);
-		addHeaderButton("회의시간추가", 975, mv);
+
+		// 관리자 전용 버튼들
+		addAdminOnlyButton("회의실추가", 440, adv);
+		addAdminOnlyButton("회의실관리", 547, rmv);
+
+		// 로그인 후에만 사용 가능한 버튼들 (처음엔 비활성화)
+		addDisabledHeaderButton("사용자정보", 226);
+		addDisabledHeaderButton("회의실예약", 654);
+		addDisabledHeaderButton("내회의관리", 761);
+		addDisabledHeaderButton("회의시간추가", 868);
 
 		change(panel, lgv); // 기본화면: 로그인 뷰
 	}
@@ -78,12 +84,119 @@ public class BaseFrame extends JFrame {
 	private void addHeaderButton(String title, int x, Container view) {
 		JButton btn = new JButton(title);
 		btn.setBounds(x, 74, 95, 23);
-		btn.addActionListener(e -> change(panel, view));
+		btn.addActionListener(e -> {
+			if (view != null) {
+				change(panel, view);
+			} else {
+				JOptionPane.showMessageDialog(this, "로그인이 필요합니다.");
+			}
+		});
 		headerPanel.add(btn);
 	}
 
-    
-    public void change(Container now, Container changed) {
+	private void addDisabledHeaderButton(String title, int x) {
+		JButton btn = new JButton(title);
+		btn.setBounds(x, 74, 95, 23);
+		btn.setEnabled(false);
+		btn.addActionListener(e -> {
+			JOptionPane.showMessageDialog(this, "로그인이 필요합니다.");
+		});
+		headerPanel.add(btn);
+	}
+
+	private void addAdminOnlyButton(String title, int x, Container view) {
+		JButton btn = new JButton(title);
+		btn.setBounds(x, 74, 95, 23);
+		btn.setEnabled(false);
+		btn.addActionListener(e -> {
+			if (currentUser != null && "admin".equals(currentUser.getRole())) {
+				if (view != null) {
+					change(panel, view);
+				}
+			} else {
+				JOptionPane.showMessageDialog(this, "관리자 권한이 필요합니다.");
+			}
+		});
+		headerPanel.add(btn);
+	}
+
+	// 로그인 후 버튼들을 활성화하고 기능을 연결하는 메서드
+	public void enableUserButtons() {
+		Component[] components = headerPanel.getComponents();
+		for (Component comp : components) {
+			if (comp instanceof JButton) {
+				JButton btn = (JButton) comp;
+				String text = btn.getText();
+
+				// 관리자 전용 버튼들
+				if (text.equals("회의실추가") || text.equals("회의실관리")) {
+					if (currentUser != null && "admin".equals(currentUser.getRole())) {
+						btn.setEnabled(true);
+					} else {
+						btn.setEnabled(false);
+					}
+					continue;
+				}
+
+				// 각 버튼에 맞는 기능 연결
+				switch (text) {
+					case "사용자정보":
+						btn.setEnabled(true);
+						// 기존 ActionListener 제거 후 새로 추가
+						btn.removeActionListener(btn.getActionListeners()[0]);
+						btn.addActionListener(e -> {
+							if (uif != null) change(panel, uif);
+						});
+						break;
+					case "회의실예약":
+					case "내회의관리":
+						btn.setEnabled(true);
+						btn.removeActionListener(btn.getActionListeners()[0]);
+						btn.addActionListener(e -> {
+							if (lv != null) change(panel, lv);
+						});
+						break;
+					case "회의시간추가":
+						btn.setEnabled(true);
+						btn.removeActionListener(btn.getActionListeners()[0]);
+						btn.addActionListener(e -> {
+							if (mv != null) change(panel, mv);
+						});
+						break;
+				}
+			}
+		}
+	}
+
+	// 로그아웃 시 버튼들을 비활성화하는 메서드
+	public void disableUserButtons() {
+		Component[] components = headerPanel.getComponents();
+		for (Component comp : components) {
+			if (comp instanceof JButton) {
+				JButton btn = (JButton) comp;
+				String text = btn.getText();
+
+				if (text.equals("사용자정보") || text.equals("회의실예약") ||
+						text.equals("내회의관리") || text.equals("회의시간추가") ||
+						text.equals("회의실추가") || text.equals("회의실관리")) {
+					btn.setEnabled(false);
+				}
+			}
+		}
+
+		// View들 초기화
+		uif = null;
+		lv = null;
+		mv = null;
+		currentUser = null;
+	}
+
+	public void change(Container now, Container changed) {
+		if (changed == null) {
+			JOptionPane.showMessageDialog(this, "해당 화면을 사용할 수 없습니다.");
+			return;
+		}
+
 		now.removeAll();
 		now.setLayout(null);
 		changed.setBounds(0, 0, 1402, 803);

--- a/src/app/Main.java
+++ b/src/app/Main.java
@@ -1,0 +1,15 @@
+package app;
+
+import javax.swing.SwingUtilities;
+import admin.RoomManagement;
+
+public class Main {
+    public static void main(String[] args) {
+        SwingUtilities.invokeLater(() -> {
+            BaseFrame baseFrame = new BaseFrame();
+            // BaseFrame 내부에 default panel이 있고, 그 위에 RoomManagement 화면을 얹음
+            baseFrame.change(baseFrame.panel, new RoomManagement(baseFrame));
+            baseFrame.setVisible(true);
+        });
+    }
+}

--- a/src/common/model/UserView.java
+++ b/src/common/model/UserView.java
@@ -10,7 +10,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 
 public class UserView extends JPanel{
-	
+
 	public JPanel userPanel;
 	public User user;
 	public JLabel infoLabel=new JLabel();
@@ -18,65 +18,106 @@ public class UserView extends JPanel{
 	public JButton userInfoBtn = new JButton();
 	public JButton addTimeBtn = new JButton();
 	public JButton reserveRoomBtn = new JButton();
-	
-	public UserView(BaseFrame baseframe) {
-		//로그인 결과 생성된 user 객체를 가져온다
-		user=baseframe.loginResult.getUser();
-		
-		setLayout(null);
-		infoLabel.setText("기능 안내 라벨");
-    	infoLabel.setFont(new Font("굴림", Font.PLAIN, 30));
-    	infoLabel.setBounds(12, 10, 317, 47);
-    	add(infoLabel);
-    	
-    	//로그아웃 버튼
-    	logoutBtn.setText("로그아웃");
-    	logoutBtn.setBounds(1271, 27, 123, 23);
-    	logoutBtn.addActionListener(new ActionListener() {
-    		public void actionPerformed(ActionEvent e) {
-    			baseframe.change(baseframe.panel, baseframe.lgv);
-    		}
-    	});
-    	add(logoutBtn);
 
-    	//사용자 정보 버튼
-    	userInfoBtn.setText("사용자 정보");
-    	userInfoBtn.setBounds(1136, 27, 123, 23);
-    	userInfoBtn.addActionListener(new ActionListener() {
-    		public void actionPerformed(ActionEvent e) {
-    			baseframe.change(baseframe.panel, baseframe.uif);
-    		}
-    	});
-    	add(userInfoBtn);
-    	
-    	//회의 시간 추가 버튼
-    	addTimeBtn.setText("회의 시간 추가");
-    	addTimeBtn.setBounds(1001, 27, 123, 23);
-    	addTimeBtn.addActionListener(new ActionListener() {
-    		public void actionPerformed(ActionEvent e) {
-    			baseframe.change(baseframe.panel, baseframe.mv);
-    		}
-    	});
-		add(addTimeBtn);
-		
-		//회의실 예약 버튼 정의
-		reserveRoomBtn=new JButton("회의실 예약");
-		reserveRoomBtn.addActionListener(new ActionListener() {
-    		public void actionPerformed(ActionEvent e) {
-    			baseframe.change(baseframe.panel, baseframe.lv);
-    		}
-    	});
-		reserveRoomBtn.setBounds(866, 27, 123, 23);
-		add(reserveRoomBtn);
-		reserveRoomBtn.setVisible(user.getRole().equals("leader"));
-		
-    	setuserPanel();
+	public UserView(BaseFrame baseframe) {
+		try {
+			//로그인 결과 생성된 user 객체를 가져온다
+			if (baseframe.loginResult != null && baseframe.loginResult.getUser() != null) {
+				user = baseframe.loginResult.getUser();
+			} else {
+				user = baseframe.getCurrentUser(); // fallback
+			}
+
+			// user가 여전히 null이면 기본값 설정
+			if (user == null) {
+				throw new IllegalStateException("로그인된 사용자 정보가 없습니다.");
+			}
+
+			setLayout(null);
+			infoLabel.setText("기능 안내 라벨");
+			infoLabel.setFont(new Font("굴림", Font.PLAIN, 30));
+			infoLabel.setBounds(12, 10, 317, 47);
+			add(infoLabel);
+
+			//로그아웃 버튼
+			logoutBtn.setText("로그아웃");
+			logoutBtn.setBounds(1271, 27, 123, 23);
+			logoutBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					// 로그아웃 처리
+					baseframe.disableUserButtons();
+					baseframe.change(baseframe.panel, baseframe.lgv);
+				}
+			});
+			add(logoutBtn);
+
+			//사용자 정보 버튼
+			userInfoBtn.setText("사용자 정보");
+			userInfoBtn.setBounds(1136, 27, 123, 23);
+			userInfoBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					if (baseframe.uif != null) {
+						baseframe.change(baseframe.panel, baseframe.uif);
+					}
+				}
+			});
+			add(userInfoBtn);
+
+			//회의 시간 추가 버튼
+			addTimeBtn.setText("회의 시간 추가");
+			addTimeBtn.setBounds(1001, 27, 123, 23);
+			addTimeBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					if (baseframe.mv != null) {
+						baseframe.change(baseframe.panel, baseframe.mv);
+					}
+				}
+			});
+			add(addTimeBtn);
+
+			//회의실 예약 버튼 정의
+			reserveRoomBtn=new JButton("회의실 예약");
+			reserveRoomBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					if (baseframe.lv != null) {
+						baseframe.change(baseframe.panel, baseframe.lv);
+					}
+				}
+			});
+			reserveRoomBtn.setBounds(866, 27, 123, 23);
+			add(reserveRoomBtn);
+
+			// 사용자 역할에 따라 버튼 가시성 설정
+			boolean isLeader = user.getRole() != null && user.getRole().equals("leader");
+			reserveRoomBtn.setVisible(isLeader);
+
+			setuserPanel();
+
+		} catch (Exception e) {
+			System.err.println("UserView 초기화 중 오류: " + e.getMessage());
+			e.printStackTrace();
+
+			// 오류 발생 시 기본 설정
+			setLayout(null);
+			JLabel errorLabel = new JLabel("사용자 정보를 불러올 수 없습니다.");
+			errorLabel.setBounds(12, 10, 400, 47);
+			errorLabel.setForeground(Color.RED);
+			add(errorLabel);
+
+			// 기본 로그아웃 버튼만 추가
+			JButton backBtn = new JButton("로그인 화면으로");
+			backBtn.setBounds(12, 60, 150, 23);
+			backBtn.addActionListener(e2 -> {
+				baseframe.change(baseframe.panel, baseframe.lgv);
+			});
+			add(backBtn);
+		}
 	}
+
 	public void setuserPanel() {
 		userPanel=new JPanel();
 		userPanel.setBounds(12, 78, 1378, 715);
 		add(userPanel);
 		userPanel.setLayout(null);
-		
 	}
 }

--- a/src/common/service/RoomSearchService.java
+++ b/src/common/service/RoomSearchService.java
@@ -1,0 +1,201 @@
+package common.service;
+
+import common.model.Room;
+import common.util.DBUtil;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 회의실 검색을 위한 공통 서비스
+ * 모든 사용자가 사용할 수 있는 회의실 조회 기능 제공
+ */
+public class RoomSearchService {
+
+    /**
+     * 모든 회의실 조회
+     */
+    public List<Room> getAllRooms() {
+        List<Room> list = new ArrayList<>();
+        String sql = "SELECT * FROM db2025_room ORDER BY capacity ASC, name ASC";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+
+            while (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                list.add(r);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("회의실 조회 중 오류: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return list;
+    }
+
+    /**
+     * 조건에 따른 회의실 검색
+     * @param searchKeyword 회의실 이름 검색어 (null 또는 빈 문자열이면 무시)
+     * @param minCapacity 최소 수용인원 (0 이하면 무시)
+     * @return 검색 조건에 맞는 회의실 목록
+     */
+    public List<Room> searchRooms(String searchKeyword, int minCapacity) {
+        List<Room> list = new ArrayList<>();
+
+        StringBuilder sqlBuilder = new StringBuilder("SELECT * FROM db2025_room WHERE 1=1");
+        List<Object> parameters = new ArrayList<>();
+
+        // 검색 키워드가 있으면 이름으로 검색
+        if (searchKeyword != null && !searchKeyword.trim().isEmpty()) {
+            sqlBuilder.append(" AND name LIKE ?");
+            parameters.add("%" + searchKeyword.trim() + "%");
+        }
+
+        // 최소 수용인원 조건
+        if (minCapacity > 0) {
+            sqlBuilder.append(" AND capacity >= ?");
+            parameters.add(minCapacity);
+        }
+
+        sqlBuilder.append(" ORDER BY capacity ASC, name ASC");
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sqlBuilder.toString())) {
+
+            // 파라미터 설정
+            for (int i = 0; i < parameters.size(); i++) {
+                stmt.setObject(i + 1, parameters.get(i));
+            }
+
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                list.add(r);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("회의실 검색 중 오류: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return list;
+    }
+
+    /**
+     * 예약 가능한 회의실 조회 (예약되지 않은 회의실만)
+     */
+    public List<Room> getAvailableRooms() {
+        List<Room> list = new ArrayList<>();
+
+        // 예약 테이블 존재 여부 확인
+        if (!tableExists("db2025_reservation")) {
+            // 예약 테이블이 없으면 모든 회의실이 예약 가능
+            return getAllRooms();
+        }
+
+        String sql = "SELECT * FROM db2025_room WHERE id NOT IN (SELECT room_id FROM db2025_reservation) ORDER BY capacity ASC, name ASC";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+
+            while (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                list.add(r);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("예약 가능한 회의실 조회 중 오류: " + e.getMessage());
+            // 오류 발생 시 모든 회의실 반환
+            return getAllRooms();
+        }
+
+        return list;
+    }
+
+    /**
+     * 예약된 회의실 조회
+     */
+    public List<Room> getReservedRooms() {
+        List<Room> list = new ArrayList<>();
+
+        if (!tableExists("db2025_reservation")) {
+            return list; // 빈 리스트 반환
+        }
+
+        String sql = "SELECT r.* FROM db2025_room r JOIN db2025_reservation res ON r.id = res.room_id ORDER BY r.capacity ASC, r.name ASC";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql);
+             ResultSet rs = stmt.executeQuery()) {
+
+            while (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                list.add(r);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("예약된 회의실 조회 중 오류: " + e.getMessage());
+        }
+
+        return list;
+    }
+
+    /**
+     * 특정 ID의 회의실 조회
+     */
+    public Room getRoomById(int roomId) {
+        String sql = "SELECT * FROM db2025_room WHERE id = ?";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, roomId);
+            ResultSet rs = stmt.executeQuery();
+
+            if (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                return r;
+            }
+
+        } catch (SQLException e) {
+            System.err.println("회의실 조회 중 오류: " + e.getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * 테이블 존재 여부 확인
+     */
+    private boolean tableExists(String tableName) {
+        try (Connection conn = DBUtil.getConnection()) {
+            DatabaseMetaData meta = conn.getMetaData();
+            ResultSet resultSet = meta.getTables(null, null, tableName, new String[]{"TABLE"});
+            return resultSet.next();
+        } catch (SQLException e) {
+            System.err.println("테이블 존재 확인 중 오류: " + e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/leader/LeaderController.java
+++ b/src/leader/LeaderController.java
@@ -2,6 +2,8 @@ package leader;
 
 import common.model.Room;
 import common.util.DBUtil;
+import common.service.RoomSearchService;
+import leader.TeamManagementService.TeamOperationResult;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -9,10 +11,60 @@ import java.util.List;
 
 public class LeaderController {
 
+    private final TeamManagementService teamService;
+
+    public LeaderController() {
+        this.teamService = new TeamManagementService();
+    }
+
+    // 테이블 존재 여부 확인
+    private boolean tableExists(String tableName) {
+        try (Connection conn = DBUtil.getConnection()) {
+            DatabaseMetaData meta = conn.getMetaData();
+            ResultSet resultSet = meta.getTables(null, null, tableName, new String[]{"TABLE"});
+            return resultSet.next();
+        } catch (SQLException e) {
+            System.err.println("테이블 존재 확인 중 오류: " + e.getMessage());
+            return false;
+        }
+    }
+
+    // 예약 테이블이 없는 경우 생성
+    private void createReservationTableIfNotExists() {
+        if (!tableExists("db2025_reservation")) {
+            String createTableSQL = """
+                CREATE TABLE IF NOT EXISTS db2025_reservation (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    room_id INT NOT NULL,
+                    user_id INT NOT NULL,
+                    people_count INT NOT NULL,
+                    reservation_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (room_id) REFERENCES db2025_room(id),
+                    FOREIGN KEY (user_id) REFERENCES db2025_user(id)
+                )
+                """;
+
+            try (Connection conn = DBUtil.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(createTableSQL)) {
+                stmt.executeUpdate();
+                System.out.println("✅ db2025_reservation 테이블이 생성되었습니다.");
+            } catch (SQLException e) {
+                System.err.println("❌ 예약 테이블 생성 실패: " + e.getMessage());
+            }
+        }
+    }
+
     public List<Room> getAvailableRooms() {
         List<Room> list = new ArrayList<>();
-        String sql = "SELECT * FROM db2025_room WHERE id NOT IN (SELECT room_id FROM db2025_reservation)";
 
+        createReservationTableIfNotExists();
+
+        String sql;
+        if (tableExists("db2025_reservation")) {
+            sql = "SELECT * FROM db2025_room WHERE id NOT IN (SELECT room_id FROM db2025_reservation)";
+        } else {
+            sql = "SELECT * FROM db2025_room";
+        }
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
@@ -27,7 +79,22 @@ public class LeaderController {
             }
 
         } catch (SQLException e) {
-            e.printStackTrace();
+            System.err.println("예약 가능한 회의실 조회 중 오류: " + e.getMessage());
+
+            try (Connection conn = DBUtil.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement("SELECT * FROM db2025_room");
+                 ResultSet rs = stmt.executeQuery()) {
+
+                while (rs.next()) {
+                    Room r = new Room();
+                    r.setId(rs.getInt("id"));
+                    r.setName(rs.getString("name"));
+                    r.setCapacity(rs.getInt("capacity"));
+                    list.add(r);
+                }
+            } catch (SQLException fallbackError) {
+                System.err.println("Fallback 조회도 실패: " + fallbackError.getMessage());
+            }
         }
 
         return list;
@@ -35,8 +102,12 @@ public class LeaderController {
 
     public List<Room> getReservedRooms() {
         List<Room> list = new ArrayList<>();
-        String sql = "SELECT r.* FROM db2025_room r JOIN db2025_reservation res ON r.id = res.room_id";
 
+        if (!tableExists("db2025_reservation")) {
+            return list;
+        }
+
+        String sql = "SELECT r.* FROM db2025_room r JOIN db2025_reservation res ON r.id = res.room_id";
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql);
@@ -51,16 +122,20 @@ public class LeaderController {
             }
 
         } catch (SQLException e) {
-            e.printStackTrace();
+            System.err.println("예약된 회의실 조회 중 오류: " + e.getMessage());
         }
 
         return list;
     }
 
     public boolean reserveRoom(int roomId, int peopleCount, int userId) {
+        createReservationTableIfNotExists();
+
+        if (isRoomAlreadyReserved(roomId)) {
+            return false;
+        }
 
         String sql = "INSERT INTO db2025_reservation (room_id, user_id, people_count) VALUES (?, ?, ?)";
-
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
@@ -68,30 +143,118 @@ public class LeaderController {
             stmt.setInt(1, roomId);
             stmt.setInt(2, userId);
             stmt.setInt(3, peopleCount);
-            stmt.executeUpdate();
-            return true;
+
+            return stmt.executeUpdate() > 0;
 
         } catch (SQLException e) {
-            e.printStackTrace();
-            return false;
+            System.err.println("회의실 예약 중 오류: " + e.getMessage());
         }
+
+        return false;
     }
 
     public boolean cancelReservation(int roomId) {
+        if (!tableExists("db2025_reservation")) {
+            return false;
+        }
 
         String sql = "DELETE FROM db2025_reservation WHERE room_id = ?";
-
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
 
             stmt.setInt(1, roomId);
-            stmt.executeUpdate();
-            return true;
+            return stmt.executeUpdate() > 0;
 
         } catch (SQLException e) {
-            e.printStackTrace();
+            System.err.println("예약 취소 중 오류: " + e.getMessage());
+        }
+
+        return false;
+    }
+
+    private boolean isRoomAlreadyReserved(int roomId) {
+        if (!tableExists("db2025_reservation")) {
             return false;
         }
+
+        String sql = "SELECT COUNT(*) FROM db2025_reservation WHERE room_id = ?";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, roomId);
+            ResultSet rs = stmt.executeQuery();
+
+            if (rs.next()) {
+                return rs.getInt(1) > 0;
+            }
+
+        } catch (SQLException e) {
+            System.err.println("예약 확인 중 오류: " + e.getMessage());
+        }
+
+        return false;
+    }
+
+    // ================ 팀 관리 기능 ================
+
+    public String getTeamMemberInfo(int teamId) {
+        return teamService.findTeamMemberInfo(teamId);
+    }
+
+    public TeamOperationResult addTeamMember(String username, int teamId) {
+        return teamService.addUserToTeam(username, teamId, teamId);
+    }
+
+    public TeamOperationResult removeTeamMember(String username, int teamId) {
+        return teamService.removeUserFromTeam(username, teamId);
+    }
+
+
+    public List<Room> searchRooms(String searchKeyword, int minCapacity) {
+        List<Room> list = new ArrayList<>();
+
+        StringBuilder sqlBuilder = new StringBuilder("SELECT * FROM db2025_room WHERE 1=1");
+        List<Object> parameters = new ArrayList<>();
+
+        // 검색 키워드가 있으면 이름으로 검색
+        if (searchKeyword != null && !searchKeyword.trim().isEmpty()) {
+            sqlBuilder.append(" AND name LIKE ?");
+            parameters.add("%" + searchKeyword.trim() + "%");
+        }
+
+        // 최소 수용인원 조건
+        if (minCapacity > 0) {
+            sqlBuilder.append(" AND capacity >= ?");
+            parameters.add(minCapacity);
+        }
+
+        sqlBuilder.append(" ORDER BY capacity ASC, name ASC");
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sqlBuilder.toString())) {
+
+            // 파라미터 설정
+            for (int i = 0; i < parameters.size(); i++) {
+                stmt.setObject(i + 1, parameters.get(i));
+            }
+
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                Room r = new Room();
+                r.setId(rs.getInt("id"));
+                r.setName(rs.getString("name"));
+                r.setCapacity(rs.getInt("capacity"));
+                list.add(r);
+            }
+
+        } catch (SQLException e) {
+            System.err.println("회의실 검색 중 오류: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return list;
     }
 }

--- a/src/leader/LeaderView.java
+++ b/src/leader/LeaderView.java
@@ -11,125 +11,415 @@ import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
 import javax.swing.JTextArea;
 import javax.swing.border.LineBorder;
+import javax.swing.border.TitledBorder;
 
 import app.BaseFrame;
 import common.model.Room;
 import common.model.UserView;
+import leader.TeamManagementService.TeamOperationResult;
 
 public class LeaderView extends UserView {
 	private JTextArea enabledRoomListArea;
 	private JTextArea reservedRoomListArea;
+	private JTextArea teamMemberArea;
 	private final LeaderController controller;
+	private final BaseFrame baseframe;
 
 	public LeaderView(BaseFrame baseframe){
 		super(baseframe);
+		this.baseframe = baseframe;
 		this.controller = new LeaderController();
-		
-		//안내 라벨 추가
-		infoLabel.setText("회의실 예약");
-		
-		//안내 라벨
-		JLabel infoLabel_2 = new JLabel("예약 가능한 회의실 목록");
-		infoLabel_2.setFont(new Font("굴림", Font.PLAIN, 24));
-		infoLabel_2.setBounds(12, 10, 276, 50);
-		userPanel.add(infoLabel_2);
-		
-		//예약 가능한 회의실 목록 출력 필드
-		enabledRoomListArea = new JTextArea();
-		enabledRoomListArea.setEditable(false);
-		enabledRoomListArea.setBorder(new LineBorder(Color.BLACK, 5));
-		JScrollPane enabledScroll = new JScrollPane(enabledRoomListArea);
-		enabledScroll.setBounds(12, 50, 500, 655);
-		userPanel.add(enabledScroll);
-		
-		//회의실 예약 버튼
-		JButton reserveRoomBtn = new JButton("회의실 예약하기");
-		reserveRoomBtn.addActionListener((ActionEvent e) -> {
-			String reservedRoomNumStr = JOptionPane.showInputDialog("예약할 회의실 번호를 입력하세요");
-			String people = JOptionPane.showInputDialog("예약 인원을 입력하세요");
 
-			try {
-				int reservedRoomNum = Integer.parseInt(reservedRoomNumStr);
-				int reservedPeopleNum = Integer.parseInt(people);
-				int userId = baseframe.getCurrentUser().getId(); // 현재 로그인한 사용자
+		try {
+			//안내 라벨 변경
+			infoLabel.setText("회의실 예약");
 
-				boolean success = controller.reserveRoom(reservedRoomNum, reservedPeopleNum, userId);
-				if (success) {
-					JOptionPane.showMessageDialog(null, "예약 성공!");
-					loadReservedRooms();
-				} else {
-					JOptionPane.showMessageDialog(null, "예약 실패");
-				}
-			} catch (NumberFormatException ex) {
-				JOptionPane.showMessageDialog(null, "숫자를 입력하세요");
-			} catch (NullPointerException ex) {
-				JOptionPane.showMessageDialog(null, "로그인이 필요합니다");
-			}
-		});
-		reserveRoomBtn.setBounds(605, 50, 177, 23);
-		userPanel.add(reserveRoomBtn);
-		
-		//현재 예약된 회의실 출력 필드
-		JLabel infoLabel_3 = new JLabel("예약된 회의실");
-		infoLabel_3.setFont(new Font("굴림", Font.PLAIN, 24));
-		infoLabel_3.setBounds(866, 10, 276, 50);
-		userPanel.add(infoLabel_3);
+			// ================ 회의실 예약 섹션 ================
 
-		reservedRoomListArea = new JTextArea();
-		reservedRoomListArea.setEditable(false);
-		reservedRoomListArea.setBorder(new LineBorder(Color.BLACK, 5));
-		JScrollPane reservedScroll = new JScrollPane(reservedRoomListArea);
-		reservedScroll.setBounds(866, 50, 500, 655);
-		userPanel.add(reservedScroll);
-		
-		//예약 취소 버튼
-		JButton cancelReservationBtn = new JButton("회의실 예약 취소하기");
-		cancelReservationBtn.addActionListener((ActionEvent e) -> {
-			String deletedRoomNumStr = JOptionPane.showInputDialog("삭제할 회의실 번호를 입력하세요");
+			// 회의실 예약 제목
+			JLabel roomManagementLabel = new JLabel("회의실 예약");
+			roomManagementLabel.setFont(new Font("굴림", Font.BOLD, 20));
+			roomManagementLabel.setBounds(12, 320, 150, 30);
+			userPanel.add(roomManagementLabel);
 
-			try {
-				int deletedRoomNum = Integer.parseInt(deletedRoomNumStr);
-				boolean success = controller.cancelReservation(deletedRoomNum);
+			//안내 라벨
+			JLabel infoLabel_2 = new JLabel("예약 가능한 회의실 목록");
+			infoLabel_2.setFont(new Font("굴림", Font.PLAIN, 16));
+			infoLabel_2.setBounds(12, 350, 276, 30);
+			userPanel.add(infoLabel_2);
 
-				if (success) {
-					JOptionPane.showMessageDialog(null, "예약 취소 완료!");
-					loadReservedRooms();
-				} else {
-					JOptionPane.showMessageDialog(null, "예약 취소 실패");
-				}
-			} catch (NumberFormatException ex) {
-				JOptionPane.showMessageDialog(null, "숫자를 입력하세요");
-			}
-		});
-		cancelReservationBtn.setBounds(605, 83, 177, 23);
-		userPanel.add(cancelReservationBtn);
-		
-		//회의실 검색 버튼
-		JButton searchRoomBtn = new JButton("회의실 검색하기");
-		searchRoomBtn.addActionListener((ActionEvent e) -> {
+			//예약 가능한 회의실 목록 출력 필드
+			enabledRoomListArea = new JTextArea();
+			enabledRoomListArea.setEditable(false);
+			enabledRoomListArea.setBorder(new LineBorder(Color.BLACK, 5));
+			JScrollPane enabledScroll = new JScrollPane(enabledRoomListArea);
+			enabledScroll.setBounds(12, 385, 500, 280);
+			userPanel.add(enabledScroll);
+
+			//회의실 예약 버튼
+			JButton reserveRoomBtn = new JButton("회의실 예약하기");
+			reserveRoomBtn.addActionListener((ActionEvent e) -> {
+				handleRoomReservation();
+			});
+			reserveRoomBtn.setBounds(605, 385, 177, 23);
+			userPanel.add(reserveRoomBtn);
+
+			//현재 예약된 회의실 출력 필드
+			JLabel infoLabel_3 = new JLabel("예약된 회의실");
+			infoLabel_3.setFont(new Font("굴림", Font.PLAIN, 16));
+			infoLabel_3.setBounds(866, 350, 276, 30);
+			userPanel.add(infoLabel_3);
+
+			reservedRoomListArea = new JTextArea();
+			reservedRoomListArea.setEditable(false);
+			reservedRoomListArea.setBorder(new LineBorder(Color.BLACK, 5));
+			JScrollPane reservedScroll = new JScrollPane(reservedRoomListArea);
+			reservedScroll.setBounds(866, 385, 500, 280);
+			userPanel.add(reservedScroll);
+
+			//예약 취소 버튼
+			JButton cancelReservationBtn = new JButton("회의실 예약 취소하기");
+			cancelReservationBtn.addActionListener((ActionEvent e) -> {
+				handleReservationCancellation();
+			});
+			cancelReservationBtn.setBounds(605, 418, 177, 23);
+			userPanel.add(cancelReservationBtn);
+
+			//회의실 검색 버튼
+			JButton searchRoomBtn = new JButton("회의실 목록 새로고침");
+			searchRoomBtn.addActionListener((ActionEvent e) -> {
+				// 회의실 목록을 새로고침
+				loadAvailableRooms();
+				loadReservedRooms();
+				JOptionPane.showMessageDialog(this, "회의실 목록이 새로고침되었습니다.",
+						"새로고침 완료", JOptionPane.INFORMATION_MESSAGE);
+			});
+			searchRoomBtn.setBounds(605, 451, 177, 23);
+			userPanel.add(searchRoomBtn);
+
+			// ================ 팀 관리 섹션 ================
+
+			// 팀 관리 제목
+			JLabel teamManagementLabel = new JLabel("팀 관리");
+			teamManagementLabel.setFont(new Font("굴림", Font.BOLD, 20));
+			teamManagementLabel.setBounds(12, 150, 100, 30);
+			userPanel.add(teamManagementLabel);
+
+			// 팀원 목록 표시 영역
+			JLabel teamMemberLabel = new JLabel("팀원 목록");
+			teamMemberLabel.setFont(new Font("굴림", Font.PLAIN, 16));
+			teamMemberLabel.setBounds(12, 185, 100, 25);
+			userPanel.add(teamMemberLabel);
+
+			teamMemberArea = new JTextArea();
+			teamMemberArea.setEditable(false);
+			teamMemberArea.setFont(new Font("Monospaced", Font.PLAIN, 12));
+			teamMemberArea.setBorder(new LineBorder(Color.DARK_GRAY, 2));
+			JScrollPane teamScroll = new JScrollPane(teamMemberArea);
+			teamScroll.setBounds(12, 215, 500, 120);
+			userPanel.add(teamScroll);
+
+			// 팀 관리 버튼들
+			JButton addMemberBtn = new JButton("팀원 추가");
+			addMemberBtn.addActionListener((ActionEvent e) -> {
+				handleAddTeamMember();
+			});
+			addMemberBtn.setBounds(605, 215, 177, 25);
+			userPanel.add(addMemberBtn);
+
+			JButton removeMemberBtn = new JButton("팀원 제거");
+			removeMemberBtn.addActionListener((ActionEvent e) -> {
+				handleRemoveTeamMember();
+			});
+			removeMemberBtn.setBounds(605, 250, 177, 25);
+			userPanel.add(removeMemberBtn);
+
+			JButton refreshTeamBtn = new JButton("팀원 목록 새로고침");
+			refreshTeamBtn.addActionListener((ActionEvent e) -> {
+				loadTeamMembers();
+			});
+			refreshTeamBtn.setBounds(605, 285, 177, 25);
+			userPanel.add(refreshTeamBtn);
+
+			// 초기 데이터 로딩
 			loadAvailableRooms();
-		});
-		searchRoomBtn.setBounds(605, 116, 177, 23);
-		userPanel.add(searchRoomBtn);
+			loadReservedRooms();
+			loadTeamMembers(); // 권한 확인은 loadTeamMembers() 내부에서 처리
 
-		// 초기 데이터 로딩
-		loadAvailableRooms();
-		loadReservedRooms();
+		} catch (Exception e) {
+			System.err.println("LeaderView 초기화 중 오류: " + e.getMessage());
+			e.printStackTrace();
+
+			// 오류 발생 시 기본 메시지 표시
+			JLabel errorLabel = new JLabel("회의실 예약 기능을 사용할 수 없습니다.");
+			errorLabel.setBounds(12, 100, 400, 30);
+			errorLabel.setForeground(Color.RED);
+			userPanel.add(errorLabel);
+		}
+	}
+
+	private void handleRoomReservation() {
+		try {
+			String roomIdStr = JOptionPane.showInputDialog(this,
+					"예약할 회의실 번호를 입력하세요:",
+					"회의실 예약", JOptionPane.QUESTION_MESSAGE);
+
+			if (roomIdStr == null || roomIdStr.trim().isEmpty()) {
+				return; // 사용자가 취소했거나 빈 값 입력
+			}
+
+			String peopleCountStr = JOptionPane.showInputDialog(this,
+					"예약 인원을 입력하세요:",
+					"예약 인원", JOptionPane.QUESTION_MESSAGE);
+
+			if (peopleCountStr == null || peopleCountStr.trim().isEmpty()) {
+				return;
+			}
+
+			int roomId = Integer.parseInt(roomIdStr.trim());
+			int peopleCount = Integer.parseInt(peopleCountStr.trim());
+
+			if (peopleCount <= 0) {
+				JOptionPane.showMessageDialog(this, "예약 인원은 1명 이상이어야 합니다.",
+						"입력 오류", JOptionPane.WARNING_MESSAGE);
+				return;
+			}
+
+			// 현재 로그인한 사용자 확인
+			if (baseframe.getCurrentUser() == null) {
+				JOptionPane.showMessageDialog(this, "로그인 정보가 없습니다. 다시 로그인해주세요.",
+						"인증 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			int userId = baseframe.getCurrentUser().getId();
+			boolean success = controller.reserveRoom(roomId, peopleCount, userId);
+
+			if (success) {
+				JOptionPane.showMessageDialog(this, "예약 성공!");
+				loadAvailableRooms();
+				loadReservedRooms();
+			} else {
+				JOptionPane.showMessageDialog(this,
+						"예약 실패했습니다. 회의실 번호를 확인해주세요.",
+						"예약 실패", JOptionPane.WARNING_MESSAGE);
+			}
+
+		} catch (NumberFormatException ex) {
+			JOptionPane.showMessageDialog(this, "숫자를 정확히 입력해주세요.",
+					"입력 오류", JOptionPane.ERROR_MESSAGE);
+		} catch (Exception ex) {
+			System.err.println("회의실 예약 중 오류: " + ex.getMessage());
+			ex.printStackTrace();
+			JOptionPane.showMessageDialog(this,
+					"예약 처리 중 오류가 발생했습니다: " + ex.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	private void handleReservationCancellation() {
+		try {
+			String roomIdStr = JOptionPane.showInputDialog(this,
+					"취소할 회의실 번호를 입력하세요:",
+					"예약 취소", JOptionPane.QUESTION_MESSAGE);
+
+			if (roomIdStr == null || roomIdStr.trim().isEmpty()) {
+				return;
+			}
+
+			int roomId = Integer.parseInt(roomIdStr.trim());
+			boolean success = controller.cancelReservation(roomId);
+
+			if (success) {
+				JOptionPane.showMessageDialog(this, "예약 취소 완료!");
+				loadAvailableRooms();
+				loadReservedRooms();
+			} else {
+				JOptionPane.showMessageDialog(this,
+						"예약 취소에 실패했습니다. 예약된 회의실인지 확인해주세요.",
+						"취소 실패", JOptionPane.WARNING_MESSAGE);
+			}
+
+		} catch (NumberFormatException ex) {
+			JOptionPane.showMessageDialog(this, "숫자를 정확히 입력해주세요.",
+					"입력 오류", JOptionPane.ERROR_MESSAGE);
+		} catch (Exception ex) {
+			System.err.println("예약 취소 중 오류: " + ex.getMessage());
+			ex.printStackTrace();
+			JOptionPane.showMessageDialog(this,
+					"예약 취소 중 오류가 발생했습니다: " + ex.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
 	}
 
 	private void loadAvailableRooms() {
-		List<Room> rooms = controller.getAvailableRooms();
-		enabledRoomListArea.setText(rooms.isEmpty() ? "예약 가능한 회의실이 없습니다." : "");
-		for (Room room : rooms) {
-			enabledRoomListArea.append("번호: " + room.getId() + ", 이름: " + room.getName() + ", 정원: " + room.getCapacity() + "명\n");
+		try {
+			List<Room> rooms = controller.getAvailableRooms();
+			enabledRoomListArea.setText("");
+
+			if (rooms.isEmpty()) {
+				enabledRoomListArea.setText("예약 가능한 회의실이 없습니다.");
+			} else {
+				StringBuilder sb = new StringBuilder();
+				for (Room room : rooms) {
+					sb.append("번호: ").append(room.getId())
+							.append(", 이름: ").append(room.getName())
+							.append(", 정원: ").append(room.getCapacity()).append("명\n");
+				}
+				enabledRoomListArea.setText(sb.toString());
+			}
+		} catch (Exception e) {
+			System.err.println("예약 가능 회의실 로딩 중 오류: " + e.getMessage());
+			enabledRoomListArea.setText("회의실 정보를 불러올 수 없습니다.");
 		}
 	}
 
 	private void loadReservedRooms() {
-		List<Room> rooms = controller.getReservedRooms();
-		reservedRoomListArea.setText(rooms.isEmpty() ? "예약된 회의실이 없습니다." : "");
-		for (Room room : rooms) {
-			reservedRoomListArea.append("번호: " + room.getId() + ", 이름: " + room.getName() + ", 정원: " + room.getCapacity() + "명\n");
+		try {
+			List<Room> rooms = controller.getReservedRooms();
+			reservedRoomListArea.setText("");
+
+			if (rooms.isEmpty()) {
+				reservedRoomListArea.setText("예약된 회의실이 없습니다.");
+			} else {
+				StringBuilder sb = new StringBuilder();
+				for (Room room : rooms) {
+					sb.append("번호: ").append(room.getId())
+							.append(", 이름: ").append(room.getName())
+							.append(", 정원: ").append(room.getCapacity()).append("명\n");
+				}
+				reservedRoomListArea.setText(sb.toString());
+			}
+		} catch (Exception e) {
+			System.err.println("예약된 회의실 로딩 중 오류: " + e.getMessage());
+			reservedRoomListArea.setText("예약 정보를 불러올 수 없습니다.");
+		}
+	}
+
+	// ================ 팀 관리 메서드들 ================
+
+	/**
+	 * 팀원 목록 로딩 (권한 확인)
+	 */
+	private void loadTeamMembers() {
+		try {
+			// 권한 확인
+			if (baseframe.getCurrentUser() == null) {
+				if (teamMemberArea != null) {
+					teamMemberArea.setText("로그인 정보가 없습니다.");
+				}
+				return;
+			}
+
+			String userRole = baseframe.getCurrentUser().getRole();
+			if (!"leader".equals(userRole) && !"admin".equals(userRole)) {
+				if (teamMemberArea != null) {
+					teamMemberArea.setText("팀 관리 권한이 없습니다.");
+				}
+				return;
+			}
+
+			int teamId = baseframe.getCurrentUser().getTeamId();
+			String memberInfo = controller.getTeamMemberInfo(teamId);
+			if (teamMemberArea != null) {
+				teamMemberArea.setText(memberInfo);
+			}
+
+		} catch (Exception e) {
+			System.err.println("팀원 목록 로딩 중 오류: " + e.getMessage());
+			if (teamMemberArea != null) {
+				teamMemberArea.setText("팀원 정보를 불러올 수 없습니다.\n오류: " + e.getMessage());
+			}
+		}
+	}
+
+	/**
+	 * 팀원 추가 처리
+	 */
+	private void handleAddTeamMember() {
+		try {
+			String username = JOptionPane.showInputDialog(this,
+					"추가할 팀원의 사용자명을 입력하세요:",
+					"팀원 추가", JOptionPane.QUESTION_MESSAGE);
+
+			if (username == null || username.trim().isEmpty()) {
+				return;
+			}
+
+			if (baseframe.getCurrentUser() == null) {
+				JOptionPane.showMessageDialog(this, "로그인 정보가 없습니다.",
+						"인증 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			int teamId = baseframe.getCurrentUser().getTeamId();
+			TeamOperationResult result = controller.addTeamMember(username.trim(), teamId);
+
+			if (result.isSuccess()) {
+				JOptionPane.showMessageDialog(this, result.getMessage(),
+						"성공", JOptionPane.INFORMATION_MESSAGE);
+				loadTeamMembers(); // 팀원 목록 새로고침
+			} else {
+				JOptionPane.showMessageDialog(this, result.getMessage(),
+						"팀원 추가 실패", JOptionPane.WARNING_MESSAGE);
+			}
+
+		} catch (Exception e) {
+			System.err.println("팀원 추가 중 오류: " + e.getMessage());
+			JOptionPane.showMessageDialog(this,
+					"팀원 추가 중 오류가 발생했습니다: " + e.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	/**
+	 * 팀원 제거 처리
+	 */
+	private void handleRemoveTeamMember() {
+		try {
+			String username = JOptionPane.showInputDialog(this,
+					"제거할 팀원의 사용자명을 입력하세요:",
+					"팀원 제거", JOptionPane.QUESTION_MESSAGE);
+
+			if (username == null || username.trim().isEmpty()) {
+				return;
+			}
+
+			// 확인 대화상자
+			int confirmation = JOptionPane.showConfirmDialog(this,
+					"정말로 '" + username.trim() + "' 사용자를 팀에서 제거하시겠습니까?\n" +
+							"제거된 사용자는 무소속 상태가 되며, 관련 예약도 취소됩니다.",
+					"팀원 제거 확인", JOptionPane.YES_NO_OPTION, JOptionPane.WARNING_MESSAGE);
+
+			if (confirmation != JOptionPane.YES_OPTION) {
+				return;
+			}
+
+			if (baseframe.getCurrentUser() == null) {
+				JOptionPane.showMessageDialog(this, "로그인 정보가 없습니다.",
+						"인증 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			int teamId = baseframe.getCurrentUser().getTeamId();
+			TeamOperationResult result = controller.removeTeamMember(username.trim(), teamId);
+
+			if (result.isSuccess()) {
+				JOptionPane.showMessageDialog(this, result.getMessage(),
+						"성공", JOptionPane.INFORMATION_MESSAGE);
+				loadTeamMembers(); // 팀원 목록 새로고침
+				loadAvailableRooms(); // 회의실 목록도 새로고침 (예약 취소로 인해)
+				loadReservedRooms();
+			} else {
+				JOptionPane.showMessageDialog(this, result.getMessage(),
+						"팀원 제거 실패", JOptionPane.WARNING_MESSAGE);
+			}
+
+		} catch (Exception e) {
+			System.err.println("팀원 제거 중 오류: " + e.getMessage());
+			JOptionPane.showMessageDialog(this,
+					"팀원 제거 중 오류가 발생했습니다: " + e.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
 		}
 	}
 }

--- a/src/leader/TeamManagementService.java
+++ b/src/leader/TeamManagementService.java
@@ -1,0 +1,269 @@
+package leader;
+
+import common.util.DBUtil;
+import common.model.User;
+import java.sql.*;
+
+public class TeamManagementService {
+
+    public String findTeamMemberInfo(int teamId) {
+        StringBuilder result = new StringBuilder();
+        String sql = """
+            SELECT u.id, u.username, u.role, t.name as team_name
+            FROM db2025_user u 
+            LEFT JOIN db2025_team t ON u.team_id = t.id
+            WHERE u.team_id = ? 
+            ORDER BY 
+                CASE u.role 
+                    WHEN 'leader' THEN 1 
+                    WHEN 'member' THEN 2 
+                    ELSE 3 
+                END, 
+                u.username ASC
+            """;
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setInt(1, teamId);
+            ResultSet rs = pstmt.executeQuery();
+
+            if (!rs.next()) {
+                return "팀원이 없습니다.";
+            }
+
+            String teamName = rs.getString("team_name");
+            result.append("=== ").append(teamName != null ? teamName : "팀 " + teamId).append(" ===\n\n");
+
+            do {
+                String role = rs.getString("role");
+                String roleDisplay = switch (role) {
+                    case "leader" -> "리더";
+                    case "member" -> "일반회원";
+                    default -> role;
+                };
+
+                result.append("• ").append(rs.getString("username"))
+                        .append(" (").append(roleDisplay).append(")")
+                        .append(" [ID: ").append(rs.getInt("id")).append("]")
+                        .append("\n");
+            } while (rs.next());
+
+        } catch (SQLException e) {
+            System.err.println("팀원 정보 조회 중 오류: " + e.getMessage());
+            return "팀원 정보를 불러올 수 없습니다.\n오류: " + e.getMessage();
+        }
+
+        return result.toString();
+    }
+
+    public User getUserByUsername(String username) {
+        String sql = """
+            SELECT u.id, u.username, u.role, u.team_id, t.name as team_name
+            FROM db2025_user u 
+            LEFT JOIN db2025_team t ON u.team_id = t.id
+            WHERE u.username = ?
+            """;
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement pstmt = conn.prepareStatement(sql)) {
+
+            pstmt.setString(1, username.trim());
+            ResultSet rs = pstmt.executeQuery();
+
+            if (rs.next()) {
+                User user = new User();
+                user.setId(rs.getInt("id"));
+                user.setUsername(rs.getString("username"));
+                user.setRole(rs.getString("role"));
+
+                Object teamIdObj = rs.getObject("team_id");
+                if (teamIdObj != null) {
+                    user.setTeamId(rs.getInt("team_id"));
+                } else {
+                    user.setTeamId(0);
+                }
+                return user;
+            }
+        } catch (SQLException e) {
+            System.err.println("사용자 조회 중 오류: " + e.getMessage());
+        }
+        return null;
+    }
+
+    public boolean isUserExists(String username) {
+        return getUserByUsername(username) != null;
+    }
+
+    public TeamOperationResult addUserToTeam(String username, int targetTeamId, int leaderTeamId) {
+        if (targetTeamId != leaderTeamId) {
+            return new TeamOperationResult(false, "자신의 팀에만 팀원을 추가할 수 있습니다.");
+        }
+
+        Connection conn = null;
+        try {
+            conn = DBUtil.getConnection();
+            conn.setAutoCommit(false);
+
+            User targetUser = getUserByUsernameWithConnection(conn, username);
+            if (targetUser == null) {
+                return new TeamOperationResult(false, "존재하지 않는 사용자입니다: " + username);
+            }
+
+            if (!"member".equals(targetUser.getRole())) {
+                return new TeamOperationResult(false, "일반 회원(member)만 팀에 추가할 수 있습니다.");
+            }
+
+            if (targetUser.getTeamId() == targetTeamId) {
+                return new TeamOperationResult(false, "이미 해당 팀에 속한 팀원입니다.");
+            }
+
+            String updateSql = "UPDATE db2025_user SET team_id = ? WHERE username = ?";
+            try (PreparedStatement pstmt = conn.prepareStatement(updateSql)) {
+                pstmt.setInt(1, targetTeamId);
+                pstmt.setString(2, username.trim());
+                int affectedRows = pstmt.executeUpdate();
+                if (affectedRows == 0) {
+                    throw new SQLException("팀원 추가 실패: 업데이트된 행이 없습니다.");
+                }
+            }
+
+            conn.commit();
+            return new TeamOperationResult(true, "팀원 '" + username + "'이(가) 성공적으로 추가되었습니다.");
+
+        } catch (SQLException e) {
+            System.err.println("팀원 추가 중 오류: " + e.getMessage());
+            if (conn != null) {
+                try {
+                    conn.rollback();
+                } catch (SQLException rollbackEx) {
+                    System.err.println("롤백 중 오류: " + rollbackEx.getMessage());
+                }
+            }
+            return new TeamOperationResult(false, "팀원 추가 중 오류가 발생했습니다: " + e.getMessage());
+        } finally {
+            if (conn != null) {
+                try {
+                    conn.setAutoCommit(true);
+                    conn.close();
+                } catch (SQLException e) {
+                    System.err.println("연결 종료 중 오류: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    public TeamOperationResult removeUserFromTeam(String username, int leaderTeamId) {
+        Connection conn = null;
+        try {
+            conn = DBUtil.getConnection();
+            conn.setAutoCommit(false);
+
+            User targetUser = getUserByUsernameWithConnection(conn, username);
+            if (targetUser == null) {
+                return new TeamOperationResult(false, "존재하지 않는 사용자입니다: " + username);
+            }
+
+            if (targetUser.getTeamId() != leaderTeamId) {
+                return new TeamOperationResult(false, "자신의 팀원만 제거할 수 있습니다.");
+            }
+
+            if ("leader".equals(targetUser.getRole())) {
+                return new TeamOperationResult(false, "리더는 팀에서 제거할 수 없습니다.");
+            }
+
+            // 관련 예약 삭제
+            deleteUserReservations(conn, targetUser.getId());
+
+            String updateSql = "UPDATE db2025_user SET team_id = NULL WHERE username = ?";
+            try (PreparedStatement pstmt = conn.prepareStatement(updateSql)) {
+                pstmt.setString(1, username.trim());
+                int affectedRows = pstmt.executeUpdate();
+                if (affectedRows == 0) {
+                    throw new SQLException("팀원 제거 실패: 업데이트된 행이 없습니다.");
+                }
+            }
+
+            conn.commit();
+            return new TeamOperationResult(true, "팀원 '" + username + "'이(가) 성공적으로 제거되었습니다.");
+
+        } catch (SQLException e) {
+            System.err.println("팀원 제거 중 오류: " + e.getMessage());
+            if (conn != null) {
+                try {
+                    conn.rollback();
+                } catch (SQLException rollbackEx) {
+                    System.err.println("롤백 중 오류: " + rollbackEx.getMessage());
+                }
+            }
+            return new TeamOperationResult(false, "팀원 제거 중 오류가 발생했습니다: " + e.getMessage());
+        } finally {
+            if (conn != null) {
+                try {
+                    conn.setAutoCommit(true);
+                    conn.close();
+                } catch (SQLException e) {
+                    System.err.println("연결 종료 중 오류: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    private User getUserByUsernameWithConnection(Connection conn, String username) throws SQLException {
+        String sql = "SELECT id, username, role, team_id FROM db2025_user WHERE username = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setString(1, username.trim());
+            ResultSet rs = pstmt.executeQuery();
+
+            if (rs.next()) {
+                User user = new User();
+                user.setId(rs.getInt("id"));
+                user.setUsername(rs.getString("username"));
+                user.setRole(rs.getString("role"));
+
+                Object teamIdObj = rs.getObject("team_id");
+                if (teamIdObj != null) {
+                    user.setTeamId(rs.getInt("team_id"));
+                } else {
+                    user.setTeamId(0);
+                }
+                return user;
+            }
+        }
+        return null;
+    }
+
+    private void deleteUserReservations(Connection conn, int userId) throws SQLException {
+        if (!tableExists(conn, "db2025_reservation")) {
+            return;
+        }
+
+        String sql = "DELETE FROM db2025_reservation WHERE user_id = ?";
+        try (PreparedStatement pstmt = conn.prepareStatement(sql)) {
+            pstmt.setInt(1, userId);
+            int deletedCount = pstmt.executeUpdate();
+            if (deletedCount > 0) {
+                System.out.println("사용자 " + userId + "의 예약 " + deletedCount + "건이 삭제되었습니다.");
+            }
+        }
+    }
+
+    private boolean tableExists(Connection conn, String tableName) throws SQLException {
+        DatabaseMetaData meta = conn.getMetaData();
+        ResultSet resultSet = meta.getTables(null, null, tableName, new String[]{"TABLE"});
+        return resultSet.next();
+    }
+
+    public static class TeamOperationResult {
+        private final boolean success;
+        private final String message;
+
+        public TeamOperationResult(boolean success, String message) {
+            this.success = success;
+            this.message = message;
+        }
+
+        public boolean isSuccess() { return success; }
+        public String getMessage() { return message; }
+    }
+}

--- a/src/login/LoginView.java
+++ b/src/login/LoginView.java
@@ -11,15 +11,15 @@ import member.MemberView;
 public class LoginView extends JPanel {
 	private JTextField textField;
 	private JTextField textField_1;
-	
+
 	public LoginView(BaseFrame baseframe) {
-		
+
 		//안내 라벨
 		JLabel lblNewLabel_1 = new JLabel("회의실 예약 시스템에 로그인하세요");
 		lblNewLabel_1.setHorizontalAlignment(SwingConstants.CENTER);
 		lblNewLabel_1.setBounds(532, 348, 279, 15);
 		add(lblNewLabel_1);
-		
+
 		JLabel lblNewLabel = new JLabel("로그인");
 		lblNewLabel.setHorizontalAlignment(SwingConstants.CENTER);
 		lblNewLabel.setBounds(532, 323, 279, 15);
@@ -34,7 +34,7 @@ public class LoginView extends JPanel {
 		idBorder.setTitleJustification(TitledBorder.LEADING);
 		textField.setBorder(idBorder);
 		add(textField);
-		
+
 		//비밀번호 입력 필드
 		textField_1 = new JTextField();
 		textField_1.setBounds(532, 423, 279, 40);
@@ -44,30 +44,63 @@ public class LoginView extends JPanel {
 		pwBorder.setTitleJustification(TitledBorder.LEADING);
 		textField_1.setBorder(pwBorder);
 		add(textField_1);
-		
+
 		//로그인 버튼
 		JButton login_btn = new JButton("로그인");
 		login_btn.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
-				//로그인 함수 실행
-				String username=textField.getText();
-				String password=textField_1.getText();
-				baseframe.loginResult=baseframe.loginController.login(username, password);
-				if(baseframe.loginResult.isSuccess()) {
-					JOptionPane.showMessageDialog(null, baseframe.loginResult.getMessage());
-					baseframe.uif=new UserInfo(baseframe);
-					baseframe.lv=new LeaderView(baseframe);
-					baseframe.mv=new MemberView(baseframe);
-					baseframe.change(baseframe.panel, baseframe.uif);
+				try {
+					//로그인 함수 실행
+					String username=textField.getText();
+					String password=textField_1.getText();
+					baseframe.loginResult=baseframe.loginController.login(username, password);
+
+					if(baseframe.loginResult.isSuccess()) {
+						JOptionPane.showMessageDialog(null, baseframe.loginResult.getMessage());
+
+						// 로그인된 사용자 정보 설정
+						baseframe.setCurrentUser(baseframe.loginResult.getUser());
+
+						// 사용자별 View 초기화
+						try {
+							baseframe.uif = new UserInfo(baseframe);
+							baseframe.lv = new LeaderView(baseframe);
+							baseframe.mv = new MemberView(baseframe);
+
+							// 헤더 버튼들 활성화
+							baseframe.enableUserButtons();
+
+							// 사용자 정보 화면으로 이동
+							baseframe.change(baseframe.panel, baseframe.uif);
+
+						} catch (Exception ex) {
+							System.err.println("View 초기화 중 오류 발생: " + ex.getMessage());
+							ex.printStackTrace();
+
+							// 오류 발생 시 기본 화면으로
+							JOptionPane.showMessageDialog(null,
+									"일부 기능 초기화 중 오류가 발생했습니다. 기본 기능만 사용 가능합니다.",
+									"Warning", JOptionPane.WARNING_MESSAGE);
+						}
+
+					} else {
+						JOptionPane.showMessageDialog(null, baseframe.loginResult.getMessage(),
+								"Message", JOptionPane.ERROR_MESSAGE);
+					}
+				} catch (Exception ex) {
+					System.err.println("로그인 처리 중 오류 발생: " + ex.getMessage());
+					ex.printStackTrace();
+					JOptionPane.showMessageDialog(null,
+							"로그인 처리 중 오류가 발생했습니다: " + ex.getMessage(),
+							"Error", JOptionPane.ERROR_MESSAGE);
 				}
-				else JOptionPane.showMessageDialog(null, baseframe.loginResult.getMessage(), "Message", JOptionPane.ERROR_MESSAGE);
 			}
 		});
 		login_btn.setForeground(new Color(255, 255, 255));
 		login_btn.setBackground(new Color(0, 0, 0));
 		login_btn.setBounds(532, 473, 279, 21);
 		add(login_btn);
-		
+
 		//회원가입 버튼
 		JButton signup_btn = new JButton("회원가입");
 		signup_btn.addActionListener(new ActionListener() {
@@ -78,5 +111,19 @@ public class LoginView extends JPanel {
 		});
 		signup_btn.setBounds(532, 523, 279, 21);
 		add(signup_btn);
+
+		// 로그아웃 버튼
+		JButton logout_btn = new JButton("로그아웃");
+		logout_btn.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+				// 로그아웃 처리
+				baseframe.disableUserButtons();
+				textField.setText("");
+				textField_1.setText("");
+				JOptionPane.showMessageDialog(null, "로그아웃되었습니다.");
+			}
+		});
+		logout_btn.setBounds(532, 554, 279, 21);
+		add(logout_btn);
 	}
 }

--- a/src/login/UserInfo.java
+++ b/src/login/UserInfo.java
@@ -22,139 +22,254 @@ public class UserInfo extends UserView {
 	public UserInfo(BaseFrame baseframe) {
 		super(baseframe);
 		this.baseframe=baseframe;
-		
-		//안내 라벨
-		infoLabel.setText("사용자 정보");
-		
-		//사용자명 라벨
-		nameInfo = new JLabel(user.getUsername());
-		nameInfo.setBounds(500, 100, 300, 40);
-		TitledBorder nameborder = new TitledBorder("사용자명");
-		nameborder.setTitlePosition(TitledBorder.ABOVE_TOP);
-		nameborder.setTitleJustification(TitledBorder.LEADING);
-		nameInfo.setBorder(nameborder);
-		
-		//소속 팀 라벨
-		teamInfo = new JLabel(Integer.toString(user.getTeamId()));
-		teamInfo.setBounds(500, 160, 300, 40);
-		TitledBorder teamborder = new TitledBorder("소속 팀");
-		teamborder.setTitlePosition(TitledBorder.ABOVE_TOP);
-		teamborder.setTitleJustification(TitledBorder.LEADING);
-		teamInfo.setBorder(teamborder);
-		
-		//역할 라벨
-		roleInfo = new JLabel(user.getRole());
-		roleInfo.setBounds(500, 220, 300, 40);
-		TitledBorder roleborder = new TitledBorder("역할");
-		roleborder.setTitlePosition(TitledBorder.ABOVE_TOP);
-		roleborder.setTitleJustification(TitledBorder.LEADING);
-		roleInfo.setBorder(roleborder);
-		
-		//비밀번호 변경 버튼
-		JButton pwChangeBtn=new JButton("비밀번호 변경하기");
-		pwChangeBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				int yes=JOptionPane.showConfirmDialog(null,"비밀번호를 변경하시겠습니까?", "confirm",JOptionPane.YES_NO_OPTION);
-				if(yes==0) {
-					String pwNow=JOptionPane.showInputDialog("현재 비밀번호를 입력하세요");
-					if(pwNow.equals(user.getPassword())) {
-						String pwNew=JOptionPane.showInputDialog("새로운 비밀번호를 입력하세요");
-						if (pwNew!=null) {
-							user.setPassword(pwNew);
-							/*db까지 변경하는 코드 필요함
-							 * 
-							 * 
-							 * 
-							 * 
-							 * 
-							 * */
-							JOptionPane.showMessageDialog(null, "비밀번호가 변경되었습니다");
-						}
-						else JOptionPane.showMessageDialog(null, "비밀번호 변경이 취소되었습니다", "Message", JOptionPane.WARNING_MESSAGE);
-					}
-					else JOptionPane.showMessageDialog(null, "비밀번호가 일치하지 않습니다", "Message", JOptionPane.WARNING_MESSAGE);
-				}
-				else JOptionPane.showMessageDialog(null, "비밀번호 변경이 취소되었습니다", "Message", JOptionPane.WARNING_MESSAGE);
+
+		try {
+			// user 객체가 정상적으로 초기화되었는지 확인
+			if (user == null) {
+				throw new IllegalStateException("사용자 정보가 없습니다.");
 			}
-		});
-		pwChangeBtn.setBounds(500, 280, 300, 40);
-		
-		//컴포넌트 추가
-		userPanel.add(nameInfo);
-		userPanel.add(teamInfo);
-		userPanel.add(roleInfo);
-		userPanel.add(pwChangeBtn);
-		
-		//여기부터는 리더에게만 보이는 컴포넌트
-		if(user.getRole().equals("leader")) setLeaderOnlyInfo();
+
+			//안내 라벨
+			infoLabel.setText("사용자 정보");
+
+			//사용자명 라벨
+			nameInfo = new JLabel(user.getUsername() != null ? user.getUsername() : "Unknown");
+			nameInfo.setBounds(500, 100, 300, 40);
+			TitledBorder nameborder = new TitledBorder("사용자명");
+			nameborder.setTitlePosition(TitledBorder.ABOVE_TOP);
+			nameborder.setTitleJustification(TitledBorder.LEADING);
+			nameInfo.setBorder(nameborder);
+
+			//소속 팀 라벨
+			teamInfo = new JLabel(String.valueOf(user.getTeamId()));
+			teamInfo.setBounds(500, 160, 300, 40);
+			TitledBorder teamborder = new TitledBorder("소속 팀 ID");
+			teamborder.setTitlePosition(TitledBorder.ABOVE_TOP);
+			teamborder.setTitleJustification(TitledBorder.LEADING);
+			teamInfo.setBorder(teamborder);
+
+			//역할 라벨
+			roleInfo = new JLabel(user.getRole() != null ? user.getRole() : "Unknown");
+			roleInfo.setBounds(500, 220, 300, 40);
+			TitledBorder roleborder = new TitledBorder("역할");
+			roleborder.setTitlePosition(TitledBorder.ABOVE_TOP);
+			roleborder.setTitleJustification(TitledBorder.LEADING);
+			roleInfo.setBorder(roleborder);
+
+			//비밀번호 변경 버튼
+			JButton pwChangeBtn=new JButton("비밀번호 변경하기");
+			pwChangeBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					handlePasswordChange();
+				}
+			});
+			pwChangeBtn.setBounds(500, 280, 300, 40);
+
+			//컴포넌트 추가
+			userPanel.add(nameInfo);
+			userPanel.add(teamInfo);
+			userPanel.add(roleInfo);
+			userPanel.add(pwChangeBtn);
+
+			//여기부터는 리더에게만 보이는 컴포넌트
+			if(user.getRole() != null && user.getRole().equals("leader")) {
+				setLeaderOnlyInfo();
+			}
+
+		} catch (Exception e) {
+			System.err.println("UserInfo 초기화 중 오류: " + e.getMessage());
+			e.printStackTrace();
+
+			// 오류 발생 시 기본 정보 표시
+			JLabel errorLabel = new JLabel("사용자 정보를 불러올 수 없습니다.");
+			errorLabel.setBounds(500, 100, 300, 40);
+			errorLabel.setForeground(Color.RED);
+			userPanel.add(errorLabel);
+
+			JButton backBtn = new JButton("로그인 화면으로");
+			backBtn.setBounds(500, 150, 150, 30);
+			backBtn.addActionListener(e2 -> {
+				baseframe.change(baseframe.panel, baseframe.lgv);
+			});
+			userPanel.add(backBtn);
+		}
 	}
+
+	private void handlePasswordChange() {
+		try {
+			int confirmation = JOptionPane.showConfirmDialog(this,
+					"비밀번호를 변경하시겠습니까?",
+					"비밀번호 변경", JOptionPane.YES_NO_OPTION);
+
+			if (confirmation != JOptionPane.YES_OPTION) {
+				JOptionPane.showMessageDialog(this, "비밀번호 변경이 취소되었습니다.",
+						"취소", JOptionPane.INFORMATION_MESSAGE);
+				return;
+			}
+
+			String currentPassword = JOptionPane.showInputDialog(this,
+					"현재 비밀번호를 입력하세요:", "현재 비밀번호", JOptionPane.QUESTION_MESSAGE);
+
+			if (currentPassword == null || currentPassword.trim().isEmpty()) {
+				JOptionPane.showMessageDialog(this, "현재 비밀번호를 입력해야 합니다.",
+						"입력 오류", JOptionPane.WARNING_MESSAGE);
+				return;
+			}
+
+			// 현재 비밀번호 확인
+			String userPassword = user.getPassword();
+			if (userPassword == null || !userPassword.equals(currentPassword.trim())) {
+				JOptionPane.showMessageDialog(this, "현재 비밀번호가 일치하지 않습니다.",
+						"인증 실패", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			String newPassword = JOptionPane.showInputDialog(this,
+					"새로운 비밀번호를 입력하세요:", "새 비밀번호", JOptionPane.QUESTION_MESSAGE);
+
+			if (newPassword == null || newPassword.trim().isEmpty()) {
+				JOptionPane.showMessageDialog(this, "비밀번호 변경이 취소되었습니다.",
+						"취소", JOptionPane.INFORMATION_MESSAGE);
+				return;
+			}
+
+			if (newPassword.trim().length() < 3) {
+				JOptionPane.showMessageDialog(this, "비밀번호는 최소 3자 이상이어야 합니다.",
+						"입력 오류", JOptionPane.WARNING_MESSAGE);
+				return;
+			}
+
+			// 비밀번호 업데이트 (실제 DB 업데이트는 추후 구현)
+			user.setPassword(newPassword.trim());
+			JOptionPane.showMessageDialog(this, "비밀번호가 변경되었습니다.\n(주의: DB에는 아직 반영되지 않았습니다)");
+
+		} catch (Exception e) {
+			System.err.println("비밀번호 변경 중 오류: " + e.getMessage());
+			JOptionPane.showMessageDialog(this,
+					"비밀번호 변경 중 오류가 발생했습니다: " + e.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
 	public void setLeaderOnlyInfo() {
-		//팀원 정보 출력 필드
-		membersInfoArea=new JTextArea();
-		membersInfoArea.setEditable(false);
-		membersInfoArea.setEditable(false);
-		TitledBorder membersborder = new TitledBorder("팀원 정보");
-		membersborder.setTitlePosition(TitledBorder.ABOVE_TOP);
-		membersborder.setTitleJustification(TitledBorder.LEADING);
-		membersInfoArea.setBorder(membersborder);
-		membersInfoArea.setBounds(500, 340, 300, 100);
-		//JTextArea에 정보 추가
-		membersInfoArea.append(findTeamMemberInfo(user.getTeamId()));
-		
-		//팀원 관리 버튼
-		addMemberBtn=new JButton("팀원 추가");
-		addMemberBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				String addedMember=JOptionPane.showInputDialog("추가할 팀원의 사용자명을 입력하세요");
-				/*1. 추가할 팀원이 존재하는 member인지 확인하고
-				 *2. member의 team을 리더의 team으로 바꾸는 함수가 필요하다
-				 * */
-				if(isUserExists(addedMember)) {
-					addUser(addedMember, user.getTeamId());
-					JOptionPane.showMessageDialog(null, "팀원이 추가되었습니다.");
-				}
-				else JOptionPane.showMessageDialog(null, "존재하지 않는 사용자입니다", "Message", JOptionPane.WARNING_MESSAGE);
+		try {
+			//팀원 정보 출력 필드
+			membersInfoArea = new JTextArea();
+			membersInfoArea.setEditable(false);
+			TitledBorder membersborder = new TitledBorder("팀원 정보");
+			membersborder.setTitlePosition(TitledBorder.ABOVE_TOP);
+			membersborder.setTitleJustification(TitledBorder.LEADING);
+			membersInfoArea.setBorder(membersborder);
+			membersInfoArea.setBounds(500, 340, 300, 100);
+
+			//JTextArea에 정보 추가 (임시 데이터)
+			String memberInfo = findTeamMemberInfo(user.getTeamId());
+			if (memberInfo != null && !memberInfo.trim().isEmpty()) {
+				membersInfoArea.append(memberInfo);
+			} else {
+				membersInfoArea.append("팀원 정보를 불러오는 중...");
 			}
-		});
-		addMemberBtn.setBounds(500,445, 300, 20);
-		
-		deleteMemberBtn=new JButton("팀원 삭제");
-		deleteMemberBtn.addActionListener(new ActionListener() {
-			public void actionPerformed(ActionEvent e) {
-				String deletedMember=JOptionPane.showInputDialog("삭제할 팀원의 사용자명을 입력하세요");
-				/*1. 삭제할 팀원이 존재하는 member인지 확인하고
-				 *2. member의 team을 무소속으로 바꾸는 함수가 필요하다
-				 * */
-				if(isUserExists(deletedMember)) {
-					addUser(deletedMember, user.getTeamId());
-					JOptionPane.showMessageDialog(null, "팀원이 삭제되었습니다.");
+
+			//팀원 관리 버튼
+			addMemberBtn = new JButton("팀원 추가");
+			addMemberBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					handleAddMember();
 				}
-				else JOptionPane.showMessageDialog(null, "존재하지 않는 사용자입니다", "Message", JOptionPane.WARNING_MESSAGE);
-			}
-		});
-		deleteMemberBtn.setBounds(500, 470, 300, 20);
-		
-		//컴포넌트 추가
-		userPanel.add(membersInfoArea);
-		userPanel.add(addMemberBtn);
-		userPanel.add(deleteMemberBtn);
+			});
+			addMemberBtn.setBounds(500, 445, 300, 20);
+
+			deleteMemberBtn = new JButton("팀원 삭제");
+			deleteMemberBtn.addActionListener(new ActionListener() {
+				public void actionPerformed(ActionEvent e) {
+					handleDeleteMember();
+				}
+			});
+			deleteMemberBtn.setBounds(500, 470, 300, 20);
+
+			//컴포넌트 추가
+			userPanel.add(membersInfoArea);
+			userPanel.add(addMemberBtn);
+			userPanel.add(deleteMemberBtn);
+
+		} catch (Exception e) {
+			System.err.println("리더 전용 정보 설정 중 오류: " + e.getMessage());
+			e.printStackTrace();
+		}
 	}
-	
-	/*1. 같은 팀에 소속된 팀원 정보 확인할 수 있는 sql문 필요
-	 *2. 팀원 삭제할 수 있는 sql문 필요
-	 *3. 팀원 추가할 수 있는 sql문 필요 (존재하는 유저인지, role이 member인지 확인 필요함) 
-	 * */
+
+	private void handleAddMember() {
+		try {
+			String memberName = JOptionPane.showInputDialog(this,
+					"추가할 팀원의 사용자명을 입력하세요:",
+					"팀원 추가", JOptionPane.QUESTION_MESSAGE);
+
+			if (memberName == null || memberName.trim().isEmpty()) {
+				return;
+			}
+
+			if (isUserExists(memberName.trim())) {
+				addUser(memberName.trim(), user.getTeamId());
+				JOptionPane.showMessageDialog(this, "팀원이 추가되었습니다.");
+				// UI 새로고침은 추후 구현
+			} else {
+				JOptionPane.showMessageDialog(this, "존재하지 않는 사용자입니다",
+						"사용자 없음", JOptionPane.WARNING_MESSAGE);
+			}
+		} catch (Exception e) {
+			System.err.println("팀원 추가 중 오류: " + e.getMessage());
+			JOptionPane.showMessageDialog(this, "팀원 추가 중 오류가 발생했습니다.",
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	private void handleDeleteMember() {
+		try {
+			String memberName = JOptionPane.showInputDialog(this,
+					"삭제할 팀원의 사용자명을 입력하세요:",
+					"팀원 삭제", JOptionPane.QUESTION_MESSAGE);
+
+			if (memberName == null || memberName.trim().isEmpty()) {
+				return;
+			}
+
+			if (isUserExists(memberName.trim())) {
+				deleteuser(memberName.trim(), user.getTeamId());
+				JOptionPane.showMessageDialog(this, "팀원이 삭제되었습니다.");
+				// UI 새로고침은 추후 구현
+			} else {
+				JOptionPane.showMessageDialog(this, "존재하지 않는 사용자입니다",
+						"사용자 없음", JOptionPane.WARNING_MESSAGE);
+			}
+		} catch (Exception e) {
+			System.err.println("팀원 삭제 중 오류: " + e.getMessage());
+			JOptionPane.showMessageDialog(this, "팀원 삭제 중 오류가 발생했습니다.",
+					"오류", JOptionPane.ERROR_MESSAGE);
+		}
+	}
+
+	/* TODO: 실제 DB 연동 메서드들 - 추후 구현 필요
+	 * 1. 같은 팀에 소속된 팀원 정보 확인할 수 있는 sql문 필요
+	 * 2. 팀원 삭제할 수 있는 sql문 필요
+	 * 3. 팀원 추가할 수 있는 sql문 필요 (존재하는 유저인지, role이 member인지 확인 필요함)
+	 */
 	public String findTeamMemberInfo(int teamid) {
 		//사용자의 정보를 하나의 string으로 만들어서 리턴
-		return null;
+		return "팀원 정보 기능은 아직 구현되지 않았습니다.";
 	}
+
 	public boolean isUserExists(String username) {
-		return true;
+		// TODO: 실제 DB 조회 구현
+		return true; // 임시로 true 반환
 	}
+
 	public void addUser(String username, int teamid) {
-		
+		// TODO: 실제 DB 업데이트 구현
+		System.out.println("팀원 추가: " + username + " to team " + teamid);
 	}
+
 	public void deleteuser(String username, int teamid) {
-		
+		// TODO: 실제 DB 업데이트 구현
+		System.out.println("팀원 삭제: " + username + " from team " + teamid);
 	}
 }

--- a/src/member/MemberView.java
+++ b/src/member/MemberView.java
@@ -12,93 +12,204 @@ public class MemberView extends UserView {
 	private final BaseFrame baseframe;
 	private final JPanel addTimePanel = new JPanel();
 	private final MemberController controller;
-	
+
 	public MemberView(BaseFrame baseframe) {
 		super(baseframe);
 		this.baseframe = baseframe;
 		this.controller = new MemberController();
-		
-		//setLayout(null);
-		//안내 라벨 설정
-		infoLabel.setText("회의 가능 시간 등록");
-		
-		//사용자 정보 버튼 추가
-		add(userInfoBtn);
-		
-		//안내 라벨 추가
-		JLabel addTimeLabel = new JLabel("가능 시간 등록");
-		addTimeLabel.setFont(new Font("굴림", Font.PLAIN, 30));
-		addTimeLabel.setHorizontalAlignment(SwingConstants.CENTER);
-		addTimeLabel.setBounds(470, 135, 396, 47);
-		userPanel.add(addTimeLabel);
-		
-		//날짜 선택
-		JButton dateChoiceBtn = new JButton("날짜 선택");
-		dateChoiceBtn.setBounds(470, 192, 192, 23);
-		dateChoiceBtn.addActionListener(e -> {
-			date = JOptionPane.showInputDialog("2000-01-01 형식으로 날짜를 입력하세요", null);
-			if (date != null && !date.isBlank()) {
-				addTime(new JLabel(), "날짜: " + date);
-			}
-		});
-		userPanel.add(dateChoiceBtn);
-		
-		//시간 선택
-		JButton timeChoiceBtn = new JButton("시간 선택");
-		timeChoiceBtn.setBounds(674, 192, 192, 23);
-		timeChoiceBtn.addActionListener(e -> handleTimeInput());
-		userPanel.add(timeChoiceBtn);
-		
-		addTimePanel.setBorder(new LineBorder(Color.BLACK, 5));
-		addTimePanel.setBounds(470, 225, 396, 267);
-		addTimePanel.setLayout(new GridLayout(0, 2, 0, 4));
-		userPanel.add(addTimePanel);
-	}
-	
-	private void handleTimeInput() {
-		if (date == null || date.isBlank()) {
-			JOptionPane.showMessageDialog(null, "날짜를 먼저 입력하세요", "", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-		
-		time = JOptionPane.showInputDialog("00:00-23:59 형식으로 시간을 입력하세요", null);
-		if (time == null || !time.matches("\\d{2}:\\d{2}-\\d{2}:\\d{2}")) {
-			JOptionPane.showMessageDialog(null, "시간 형식이 올바르지 않습니다", "", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-		
-		String[] parts = time.split("-");
-		String start = parts[0];
-		String end = parts[1];
-		
-		User currentUser = baseframe.getCurrentUser();
-		if (currentUser == null) {
-			JOptionPane.showMessageDialog(null, "로그인 정보가 없습니다", "", JOptionPane.ERROR_MESSAGE);
-			return;
-		}
-		
+
 		try {
-			boolean saved = controller.saveTimePreference(currentUser, date, start, end, 1);
-			if (saved) {
-				addTime(new JLabel(), date + " " + time);
-				JOptionPane.showMessageDialog(null, "회의 가능 시간이 등록되었습니다.");
-			} else {
-				JOptionPane.showMessageDialog(null, "저장에 실패했습니다.");
+			//안내 라벨 설정
+			infoLabel.setText("회의 가능 시간 등록");
+
+			//사용자 정보 버튼 추가
+			add(userInfoBtn);
+
+			//안내 라벨 추가
+			JLabel addTimeLabel = new JLabel("가능 시간 등록 (우선순위 기반)");
+			addTimeLabel.setFont(new Font("굴림", Font.PLAIN, 30));
+			addTimeLabel.setHorizontalAlignment(SwingConstants.CENTER);
+			addTimeLabel.setBounds(470, 135, 396, 47);
+			userPanel.add(addTimeLabel);
+
+			// 설명 라벨 추가
+			JLabel descLabel = new JLabel("1~3순위로 회의 가능 시간을 등록해주세요");
+			descLabel.setFont(new Font("굴림", Font.PLAIN, 14));
+			descLabel.setHorizontalAlignment(SwingConstants.CENTER);
+			descLabel.setBounds(470, 175, 396, 20);
+			userPanel.add(descLabel);
+
+			//날짜 선택
+			JButton dateChoiceBtn = new JButton("날짜 선택");
+			dateChoiceBtn.setBounds(470, 205, 192, 23);
+			dateChoiceBtn.addActionListener(e -> {
+				try {
+					String inputDate = JOptionPane.showInputDialog(this,
+							"2000-01-01 형식으로 날짜를 입력하세요",
+							"날짜 입력", JOptionPane.QUESTION_MESSAGE);
+
+					if (inputDate != null && !inputDate.trim().isBlank()) {
+						// 날짜 형식 간단 검증
+						if (inputDate.matches("\\d{4}-\\d{2}-\\d{2}")) {
+							date = inputDate.trim();
+							addTime(new JLabel(), "날짜: " + date);
+						} else {
+							JOptionPane.showMessageDialog(this,
+									"날짜 형식이 올바르지 않습니다. YYYY-MM-DD 형식으로 입력하세요.",
+									"입력 오류", JOptionPane.ERROR_MESSAGE);
+						}
+					}
+				} catch (Exception ex) {
+					System.err.println("날짜 선택 중 오류: " + ex.getMessage());
+					JOptionPane.showMessageDialog(this,
+							"날짜 선택 중 오류가 발생했습니다.",
+							"오류", JOptionPane.ERROR_MESSAGE);
+				}
+			});
+			userPanel.add(dateChoiceBtn);
+
+			//시간 및 선호도 선택
+			JButton timeChoiceBtn = new JButton("시간 및 선호도 입력");
+			timeChoiceBtn.setBounds(674, 205, 192, 23);
+			timeChoiceBtn.addActionListener(e -> handleTimeInput());
+			userPanel.add(timeChoiceBtn);
+
+			addTimePanel.setBorder(new LineBorder(Color.BLACK, 5));
+			addTimePanel.setBounds(470, 240, 396, 252);
+			addTimePanel.setLayout(new GridLayout(0, 1, 0, 2));
+			userPanel.add(addTimePanel);
+
+		} catch (Exception e) {
+			System.err.println("MemberView 초기화 중 오류: " + e.getMessage());
+			e.printStackTrace();
+
+			// 오류 발생 시 기본 메시지 표시
+			JLabel errorLabel = new JLabel("회의 시간 등록 기능을 사용할 수 없습니다.");
+			errorLabel.setBounds(12, 100, 400, 30);
+			errorLabel.setForeground(Color.RED);
+			userPanel.add(errorLabel);
+		}
+	}
+
+	private void handleTimeInput() {
+		try {
+			if (date == null || date.isBlank()) {
+				JOptionPane.showMessageDialog(this, "날짜를 먼저 입력하세요",
+						"입력 순서 오류", JOptionPane.WARNING_MESSAGE);
+				return;
 			}
+
+			// 시간 입력 패널 생성
+			JPanel timeInputPanel = new JPanel(new GridLayout(3, 2, 5, 5));
+
+			JLabel timeLabel = new JLabel("시간 (예: 09:00-10:30):");
+			JTextField timeField = new JTextField();
+
+			JLabel priorityLabel = new JLabel("선호도 (1~3순위):");
+			JComboBox<String> priorityCombo = new JComboBox<>(new String[]{"1순위 (가장 선호)", "2순위", "3순위"});
+
+			timeInputPanel.add(timeLabel);
+			timeInputPanel.add(timeField);
+			timeInputPanel.add(priorityLabel);
+			timeInputPanel.add(priorityCombo);
+
+			int result = JOptionPane.showConfirmDialog(this, timeInputPanel,
+					"회의 가능 시간 등록", JOptionPane.OK_CANCEL_OPTION, JOptionPane.QUESTION_MESSAGE);
+
+			if (result != JOptionPane.OK_OPTION) {
+				return; // 사용자가 취소
+			}
+
+			String inputTime = timeField.getText().trim();
+			if (inputTime.isEmpty()) {
+				JOptionPane.showMessageDialog(this, "시간을 입력해주세요.",
+						"입력 오류", JOptionPane.WARNING_MESSAGE);
+				return;
+			}
+
+			time = inputTime;
+
+			if (!time.matches("\\d{2}:\\d{2}-\\d{2}:\\d{2}")) {
+				JOptionPane.showMessageDialog(this,
+						"시간 형식이 올바르지 않습니다.\n00:00-23:59 형식으로 입력하세요.",
+						"형식 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			String[] parts = time.split("-");
+			String start = parts[0];
+			String end = parts[1];
+
+			// 시간 유효성 검사
+			if (!isValidTime(start) || !isValidTime(end)) {
+				JOptionPane.showMessageDialog(this,
+						"유효하지 않은 시간입니다. 00:00-23:59 범위로 입력하세요.",
+						"시간 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			User currentUser = baseframe.getCurrentUser();
+			if (currentUser == null) {
+				JOptionPane.showMessageDialog(this,
+						"로그인 정보가 없습니다. 다시 로그인해주세요.",
+						"인증 오류", JOptionPane.ERROR_MESSAGE);
+				return;
+			}
+
+			// 선호도 값 가져오기 (1, 2, 3)
+			int priority = priorityCombo.getSelectedIndex() + 1;
+
+			boolean saved = controller.saveTimePreference(currentUser, date, start, end, priority);
+			if (saved) {
+				String priorityText = priority + "순위";
+				addTime(new JLabel(), date + " " + time + " (" + priorityText + ")");
+				JOptionPane.showMessageDialog(this,
+						"회의 가능 시간이 " + priorityText + "로 등록되었습니다.");
+			} else {
+				JOptionPane.showMessageDialog(this,
+						"저장에 실패했습니다. 다시 시도해주세요.",
+						"저장 실패", JOptionPane.ERROR_MESSAGE);
+			}
+
 		} catch (Exception ex) {
-			JOptionPane.showMessageDialog(null, "오류: " + ex.getMessage());
+			System.err.println("시간 입력 처리 중 오류: " + ex.getMessage());
 			ex.printStackTrace();
+			JOptionPane.showMessageDialog(this,
+					"시간 등록 중 오류가 발생했습니다: " + ex.getMessage(),
+					"오류", JOptionPane.ERROR_MESSAGE);
 		} finally {
+			// 입력 완료 후 초기화
 			date = null;
 			time = null;
 		}
 	}
-	
+
+	// 시간 유효성 검사 (HH:MM 형식이 유효한 시간인지 확인)
+	private boolean isValidTime(String timeStr) {
+		try {
+			String[] parts = timeStr.split(":");
+			if (parts.length != 2) return false;
+
+			int hour = Integer.parseInt(parts[0]);
+			int minute = Integer.parseInt(parts[1]);
+
+			return (hour >= 0 && hour <= 23) && (minute >= 0 && minute <= 59);
+		} catch (NumberFormatException e) {
+			return false;
+		}
+	}
+
 	//textArea에 추가한 시간 보이도록
 	public void addTime(JLabel label, String timeText) {
-		label.setText(timeText);
-		addTimePanel.add(label);
-		addTimePanel.revalidate();
-		addTimePanel.repaint();
+		try {
+			label.setText(timeText);
+			label.setBorder(BorderFactory.createLineBorder(Color.GRAY));
+			label.setHorizontalAlignment(SwingConstants.CENTER);
+			addTimePanel.add(label);
+			addTimePanel.revalidate();
+			addTimePanel.repaint();
+		} catch (Exception e) {
+			System.err.println("시간 표시 중 오류: " + e.getMessage());
+		}
 	}
 }

--- a/src/member/TimePreferenceManager.java
+++ b/src/member/TimePreferenceManager.java
@@ -7,9 +7,54 @@ import java.time.LocalDateTime;
 
 public class TimePreferenceManager {
 
+    // 테이블 존재 여부 확인
+    private boolean tableExists(String tableName) {
+        try (Connection conn = DBUtil.getConnection()) {
+            DatabaseMetaData meta = conn.getMetaData();
+            ResultSet resultSet = meta.getTables(null, null, tableName, new String[]{"TABLE"});
+            return resultSet.next();
+        } catch (SQLException e) {
+            System.err.println("테이블 존재 확인 중 오류: " + e.getMessage());
+            return false;
+        }
+    }
+
+    // 시간 선호도 테이블이 없는 경우 생성
+    private void createTimePreferenceTableIfNotExists() {
+        String tableName = "db2025_timeslot";
+
+        if (!tableExists(tableName)) {
+            String createTableSQL = """
+                CREATE TABLE IF NOT EXISTS db2025_timeslot (
+                    id INT AUTO_INCREMENT PRIMARY KEY,
+                    user_id INT NOT NULL,
+                    team_id INT NOT NULL,
+                    start_time DATETIME NOT NULL,
+                    end_time DATETIME NOT NULL,
+                    priority INT DEFAULT 1,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY (user_id) REFERENCES db2025_user(id),
+                    FOREIGN KEY (team_id) REFERENCES db2025_team(id)
+                )
+                """;
+
+            try (Connection conn = DBUtil.getConnection();
+                 PreparedStatement stmt = conn.prepareStatement(createTableSQL)) {
+                stmt.executeUpdate();
+                System.out.println("✅ db2025_timeslot 테이블이 생성되었습니다.");
+            } catch (SQLException e) {
+                System.err.println("❌ 시간 선호도 테이블 생성 실패: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+    }
+
     // 회의 가능 시간 등록
     public boolean save(TimePreference tp) {
-        String sql = "INSERT INTO timeslot (user_id, team_id, start_time, end_time, priority) VALUES (?, ?, ?, ?, ?)";
+        // 테이블 존재 확인 및 생성
+        createTimePreferenceTableIfNotExists();
+
+        String sql = "INSERT INTO db2025_timeslot (user_id, team_id, start_time, end_time, priority) VALUES (?, ?, ?, ?, ?)";
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement pstmt = conn.prepareStatement(sql)) {
@@ -20,19 +65,31 @@ public class TimePreferenceManager {
             pstmt.setTimestamp(4, Timestamp.valueOf(tp.getEndTime()));
             pstmt.setInt(5, tp.getPriority());
 
-            pstmt.executeUpdate();
-            return true;
+            int result = pstmt.executeUpdate();
+            if (result > 0) {
+                System.out.println("✅ 시간 선호도 저장 성공");
+                return true;
+            }
 
         } catch (SQLException e) {
             System.err.println("시간 등록 실패: " + e.getMessage());
-            return false;
+            e.printStackTrace();
         }
+
+        return false;
     }
 
     // 사용자별 회의 가능 시간 목록 조회
     public List<TimePreference> getAllByUser(int userId) {
         List<TimePreference> list = new ArrayList<>();
-        String sql = "SELECT * FROM db2025_timeslot WHERE user_id = ? ORDER BY priority ASC";
+
+        // 테이블이 없으면 빈 리스트 반환
+        if (!tableExists("db2025_timeslot")) {
+            System.out.println("시간 선호도 테이블이 없습니다.");
+            return list;
+        }
+
+        String sql = "SELECT * FROM db2025_timeslot WHERE user_id = ? ORDER BY priority ASC, start_time ASC";
 
         try (Connection conn = DBUtil.getConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
@@ -45,16 +102,77 @@ public class TimePreferenceManager {
                 tp.setId(rs.getInt("id"));
                 tp.setUserId(rs.getInt("user_id"));
                 tp.setTeamId(rs.getInt("team_id"));
-                tp.setStartTime(rs.getTimestamp("startTime").toLocalDateTime());
-                tp.setEndTime(rs.getTimestamp("endTime").toLocalDateTime());
+                tp.setStartTime(rs.getTimestamp("start_time").toLocalDateTime());
+                tp.setEndTime(rs.getTimestamp("end_time").toLocalDateTime());
                 tp.setPriority(rs.getInt("priority"));
 
                 list.add(tp);
             }
         } catch (SQLException e) {
+            System.err.println("시간 선호도 조회 실패: " + e.getMessage());
             e.printStackTrace();
         }
 
         return list;
+    }
+
+    // 팀별 회의 가능 시간 목록 조회
+    public List<TimePreference> getAllByTeam(int teamId) {
+        List<TimePreference> list = new ArrayList<>();
+
+        if (!tableExists("db2025_timeslot")) {
+            System.out.println("시간 선호도 테이블이 없습니다.");
+            return list;
+        }
+
+        String sql = "SELECT * FROM db2025_timeslot WHERE team_id = ? ORDER BY start_time ASC, priority ASC";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, teamId);
+            ResultSet rs = stmt.executeQuery();
+
+            while (rs.next()) {
+                TimePreference tp = new TimePreference();
+                tp.setId(rs.getInt("id"));
+                tp.setUserId(rs.getInt("user_id"));
+                tp.setTeamId(rs.getInt("team_id"));
+                tp.setStartTime(rs.getTimestamp("start_time").toLocalDateTime());
+                tp.setEndTime(rs.getTimestamp("end_time").toLocalDateTime());
+                tp.setPriority(rs.getInt("priority"));
+
+                list.add(tp);
+            }
+        } catch (SQLException e) {
+            System.err.println("팀 시간 선호도 조회 실패: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return list;
+    }
+
+    // 시간 선호도 삭제
+    public boolean delete(int id) {
+        if (!tableExists("db2025_timeslot")) {
+            return false;
+        }
+
+        String sql = "DELETE FROM db2025_timeslot WHERE id = ?";
+
+        try (Connection conn = DBUtil.getConnection();
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+
+            stmt.setInt(1, id);
+            int result = stmt.executeUpdate();
+
+            return result > 0;
+
+        } catch (SQLException e) {
+            System.err.println("시간 선호도 삭제 실패: " + e.getMessage());
+            e.printStackTrace();
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
회의실 예약 시스템 UI 권한 제어 및 팀 관리 기능 개선

---
## ✅ 작업 내용 요약
- 사용자 역할(admin/leader/member)에 따른 UI 권한 제어 구현
- 팀 관리 기능을 leader/admin 전용으로 제한
- 회의실 검색 기능을 공통 서비스로 분리하여 재사용성 향상
- 시간 선호도 등록 시 우선순위(1~3순위) 기능 추가
- 트랜잭션 기반 팀원 관리 서비스 구현

---
## 🔍 변경 사항 상세
- [x] 화면(UI) 변경 있음 (예: 버튼 추가, 레이아웃 수정 등)
- [x] DB 연동/쿼리 로직 변경 있음
- [x] 기타 주요 로직 수정 있음

**상세 설명:**
- `BaseFrame`에 역할 기반 버튼 제어 로직 추가 (`addAdminOnlyButton`, `addRoleBasedHeaderButton`)
- `LeaderView`에서 팀 관리 UI를 leader/admin만 볼 수 있도록 권한 검증 추가
- `MemberView`에서 시간 등록 시 우선순위 선택 ComboBox 추가
- `RoomSearchService` 클래스 신규 생성으로 회의실 검색 로직 공통화
- `TeamManagementService`에 트랜잭션 기반 팀원 추가/제거 기능 구현
- 회의실 검색 탭 제거 및 예약 탭을 역할별로 다른 화면으로 연결

---
## 🧪 테스트 방법
- **권한 테스트**: admin/leader/member 각 역할로 로그인하여 UI 접근 권한 확인
- **팀 관리 테스트**: leader 계정으로 팀원 추가/제거 기능 동작 확인
- **우선순위 테스트**: member 계정으로 1~3순위 시간 선호도 등록 확인
- **회의실 검색 테스트**: 이름 및 수용인원 조건으로 회의실 검색 기능 확인
- **DB 트랜잭션 테스트**: 팀원 제거 시 관련 예약도 함께 삭제되는지 확인

---
## 📝 기타 참고 사항
- **리뷰 포인트**: `TeamManagementService`의 트랜잭션 롤백 로직 검토 필요
- **TODO**: 회의실 예약 시 시간 충돌 검증 로직 추가 예정
- **주의사항**: `BaseFrame`의 버튼 권한 제어가 복잡해져서 추후 리팩토링 고려 필요
- **DB 스키마**: `db2025_reservation`, `db2025_timeslot` 테이블이 없으면 자동 생성됨